### PR TITLE
Adding support for reading stylistic set names out of the font.

### DIFF
--- a/Lib/compositor/__init__.py
+++ b/Lib/compositor/__init__.py
@@ -100,6 +100,15 @@ class Font(object):
             raise CompositorError("Could not extract name data from name table.")
         self.info.familyName = familyName
         self.info.styleName = styleName
+        # stylistic set names
+        self.stylisticSetNames = {}
+        for i in range(20):
+            ssNameID = 256 + i
+            ssTag = "ss%02i" % (i + 1)
+            namePriority = [(ssNameID, 1, 0, 0), (ssNameID, 1, None, None), (ssNameID, 3, 1, 1033), (ssNameID, 3, None, None)]
+            ssName = self._skimNameIDs(nameIDs, namePriority)
+            if ssName:
+                self.stylisticSetNames[ssTag] = ssName
 
     def _skimNameIDs(self, nameIDs, priority):
         for (nameID, platformID, platEncID, langID) in priority:


### PR DESCRIPTION
I believe I added this in a way that looks like it fits with what was already there: just after it takes other names out of the name table, and I'm using the same self._skimNameIDs() method.

There will be another related pull request in defconAppKit/controls/openTypeControls.py to add these stylistic set names into the control that FeaturePreview makes use of.
